### PR TITLE
Display all applications (RVD+external) in request urls dropdowns

### DIFF
--- a/restcomm/restcomm.ui/src/main/webapp/resources/js/controllers/events.js
+++ b/restcomm/restcomm.ui/src/main/webapp/resources/js/controllers/events.js
@@ -1,26 +1,6 @@
 'use strict';
 
 angular.module('rcApp').controller('EventsCtrl', function ($rootScope, rappService, $state, Notifications) {
-	//console.log("INSIDE EventsCtrl");
-	$rootScope.$on("incoming-number-updated", function (event, data) {
-        //console.log("new incoming-number-updated event with the following data: ");
-        //console.log(data);
-        // is there a voice_url ? Only voice_urls support provisioning
-        if ( data.params.VoiceUrl ) {
-            rappService.getLocalApps().then(function (localApps) {
-                //console.log("Just received local apps. will now go through local apps and search for the voice_url " + data.params.VoiceUrl);
-                //console.log(localApps);
-                var app = rappService.getAppByUrl(localApps, data.params.VoiceUrl);
-                if (app) {
-                    //console.log("Will notify " + app.projectName + " app");
-                    //console.log(app);
-                    rappService.notifyIncomingNumberProvisioning(app, data.params.PhoneNumber);
-                } else {
-                    //console.log("no application matched");
-                }
-            });
-        }
-	});
 
 	$rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams, options){
 	    //console.log("switching states: " + fromState.name + " -> " + toState.name);

--- a/restcomm/restcomm.ui/src/main/webapp/resources/js/controllers/numbers-incoming.js
+++ b/restcomm/restcomm.ui/src/main/webapp/resources/js/controllers/numbers-incoming.js
@@ -108,7 +108,7 @@ rcMod.controller('NumbersCtrl', function ($scope, $resource, $uibModal, $dialog,
 
 // Numbers : Incoming : Details (also used for Modal) --------------------------
 
-rcMod.controller('NumberDetailsCtrl', function ($scope, $stateParams, $location, $dialog, $uibModalInstance, SessionService, RCommNumbers, RCommApps, RCommAvailableNumbers, Notifications, allCountries, providerCountries, localApps, $rootScope, AuthService, Applications) {
+rcMod.controller('NumberDetailsCtrl', function ($scope, $stateParams, $location, $dialog, $uibModalInstance, SessionService, RCommNumbers, RCommAvailableNumbers, Notifications, allCountries, providerCountries, localApps, $rootScope, AuthService, Applications) {
 
   // are we editing details...
   //if($scope.phoneSid === $stateParams.phoneSid) {
@@ -148,7 +148,6 @@ rcMod.controller('NumberDetailsCtrl', function ($scope, $stateParams, $location,
     RCommNumbers.update({accountSid: $scope.sid, phoneSid: $scope.phoneSid}, $.param(params),
       function() { // success
         Notifications.success('Number "' + number.phone_number + '" updated successfully!');
-        $rootScope.$broadcast("incoming-number-updated", {phoneSid:$scope.phoneSid, params: params});
         $location.path( "/numbers/incoming" );
       },
       function() { // error
@@ -188,7 +187,7 @@ rcMod.controller('NumberDetailsCtrl', function ($scope, $stateParams, $location,
   }
 });
 
-rcMod.controller('NumberRegisterCtrl', function ($scope, $stateParams, $location, $http, $dialog, SessionService, RCommNumbers, RCommApps, RCommAvailableNumbers, Notifications, allCountries, providerCountries) {
+rcMod.controller('NumberRegisterCtrl', function ($scope, $stateParams, $location, $http, $dialog, SessionService, RCommNumbers, RCommAvailableNumbers, Notifications, allCountries, providerCountries) {
 
   $scope.sid = SessionService.get("sid");
 

--- a/restcomm/restcomm.ui/src/main/webapp/resources/js/controllers/numbers-sip-clients.js
+++ b/restcomm/restcomm.ui/src/main/webapp/resources/js/controllers/numbers-sip-clients.js
@@ -4,7 +4,7 @@ var rcMod = angular.module('rcApp');
 
 // Numbers : RestComm Clients : List ------------------------------------------------
 
-rcMod.controller('ClientsCtrl', function($scope, $resource, $uibModal, $dialog, SessionService, RCommClients, RCommApps, Notifications) {
+rcMod.controller('ClientsCtrl', function($scope, $resource, $uibModal, $dialog, SessionService, RCommClients, Notifications) {
 
   $scope.sid = SessionService.get("sid");
 
@@ -56,7 +56,7 @@ rcMod.controller('ClientsCtrl', function($scope, $resource, $uibModal, $dialog, 
 
 // Numbers : RestComm Clients : Details (also used for Modal) -----------------------
 
-rcMod.controller('ClientDetailsCtrl', function ($scope, $stateParams, $location, $dialog, $uibModalInstance, SessionService, RCommClients, RCommApps, Notifications, localApps, Applications) {
+rcMod.controller('ClientDetailsCtrl', function ($scope, $stateParams, $location, $dialog, $uibModalInstance, SessionService, RCommClients, Notifications, localApps, Applications) {
 
   $scope.localApps = Applications.filterByKind(localApps,'voice');
 
@@ -75,9 +75,6 @@ rcMod.controller('ClientDetailsCtrl', function ($scope, $stateParams, $location,
       $uibModalInstance.dismiss('cancel');
     };
   }
-
-  // query for available apps
-  //$scope.availableApps = RCommApps.query();
 
   var createSIPClientParams = function(client) {
     var params = {};

--- a/restcomm/restcomm.ui/src/main/webapp/resources/js/restcomm.js
+++ b/restcomm/restcomm.ui/src/main/webapp/resources/js/restcomm.js
@@ -149,7 +149,7 @@ rcMod.config(['$stateProvider','$urlRouterProvider', function($stateProvider, $u
         $uibModalInstance : function() {return undefined;},
         allCountries : function() {return undefined;},
         providerCountries : function() {return undefined;},
-        localApps: function (rappService, authorize) { return rappService.refreshLocalApps();}
+        localApps: function (RCommApplications, AuthService, authorize) { return RCommApplications.query({accountSid:AuthService.getAccountSid()}).$promise;}
     }
   });
   $stateProvider.state('restcomm.applications',{
@@ -188,7 +188,7 @@ rcMod.config(['$stateProvider','$urlRouterProvider', function($stateProvider, $u
     controller: 'ClientDetailsCtrl',
     resolve: {
         $uibModalInstance : function() {return undefined;},
-        localApps: function (rappService,authorize) { return rappService.refreshLocalApps();}
+        localApps: function (RCommApplications, AuthService, authorize) { return RCommApplications.query({accountSid:AuthService.getAccountSid()}).$promise;}
     }
   });
   $stateProvider.state('restcomm.numbers-outgoing',{

--- a/restcomm/restcomm.ui/src/main/webapp/resources/js/services.js
+++ b/restcomm/restcomm.ui/src/main/webapp/resources/js/services.js
@@ -670,11 +670,6 @@ rcServices.factory('RCommLogsTranscriptions', function($resource) {
   );
 });
 
-// TODO remove obsolete project service for RAS
-rcServices.factory('RCommApps', function($resource) {
-	  return $resource('/restcomm-rvd/services/projects');
-});
-
 rcServices.factory('RCommApplications', function($resource) {
     return $resource('/restcomm/2012-04-24/Accounts/:accountSid/Applications/:applicationSid.json', {
         accountSid: '@accountSid',

--- a/restcomm/restcomm.ui/src/main/webapp/templates/rc-endpoint-url.html
+++ b/restcomm/restcomm.ui/src/main/webapp/templates/rc-endpoint-url.html
@@ -1,7 +1,7 @@
 <div class="col-md-2 col-sm-2 col-xs-12">
     <select ng-change="onTargetChanged(targetVar)" ng-model="targetVar" class="rc-selection-picker">
-        <option value="URL">URL</option>
-        <option value="Application">RVD Application</option>
+        <option value="URL">RCML URL</option>
+        <option value="Application">Application</option>
     </select>
 </div>
 <div class="clearfix visible-xs">&nbsp;</div>
@@ -20,7 +20,7 @@
     <select ng-change="setApp()" class="rc-selection-picker" ng-model="appNameVar">
         <option value="">No application selected</option>
         <option value="create_new_project">Create new project</option>
-        <option ng-repeat="app in apps | orderBy:'projectName'" value={{app.sid}}>{{ app.projectName }}</option>
+        <option ng-repeat="app in apps | orderBy:'projectName'" value={{app.sid}}>{{ app.friendly_name }}</option>
     </select>
 </div>
 


### PR DESCRIPTION
* changed labels to "RCML URL|Application" instead of "URL|RVD applicatio"
* removed filtering of application based on whether they exist in RVD or not
* removed hook of number saving and event for RAS and cleanup

Fixes RestComm/Restcomm-Connect#2655